### PR TITLE
Make it possible to abort the pull-stream when there are no listeners left

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,28 @@ $ npm install mutant-pull-reduce --save
 var pullReduce = require('mutant-pull-reduce')
 ```
 
-### `pullReduce(stream, reducer, opts)`
+### `pullReduce(getStream, reducer, opts)`
 
-**`stream`:** A `source` or `through` [pull-stream](https://github.com/pull-stream/pull-stream) to suck data from.
+**`getStream(lastValue)`:** A function that returns a `source` or `through` [pull-stream](https://github.com/pull-stream/pull-stream) to suck data from when the observable is subscribed to for the first time (or resumed later after all the previous subscribers unsubscribed).
+
+The getStream function should accept an argument that is the latest value in the stream (or null if the stream has not began.) It is invoked to get the stream to reduce when:
+* The observable is subscribed to for the first time.
+* The observable is re-subscribed to after all subscribers have previously unsubscribed.
+
+The getStream function should use the latest value to resume the stream from it's last position (or from the start if the argument is null.)
+
+E.g.:
+
+```
+function getStream (lastItem) {
+  if (lastItem) {
+    // resume (with some gt/lt option)
+    // or if return nothing, then reducer doesn't resume
+  } else {
+    // stream from start
+  }
+}
+```
 
 **`reducer(lastValue, item)`**: expects the new value to be returned
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Reduce the output of a pull-stream into a mutant observable.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "browserify test/*.js | tape-run | tap-spec"
   },
   "repository": {
     "type": "git",
@@ -27,5 +27,12 @@
     "mutant": "^3.14.1",
     "pull-abortable": "^4.1.1",
     "pull-stream": "^3.5.0"
+  },
+  "devDependencies": {
+    "browserify": "^13.1.1",
+    "setimmediate": "^1.0.5",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.3",
+    "tape-run": "^2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/mmckegg/mutant-pull-reduce#readme",
   "dependencies": {
     "mutant": "^3.14.1",
+    "pull-abortable": "^4.1.1",
     "pull-pause": "0.0.0",
     "pull-stream": "^3.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "mutant": "^3.14.1",
     "pull-abortable": "^4.1.1",
-    "pull-pause": "0.0.0",
     "pull-stream": "^3.5.0"
   }
 }

--- a/test/test-resume-stream.js
+++ b/test/test-resume-stream.js
@@ -1,0 +1,95 @@
+require('setimmediate')
+
+var test = require('tape')
+var MutantPullReduce = require('../index')
+var watch = require('mutant/watch')
+var onceTrue = require('mutant/once-true')
+var computed = require('mutant/computed')
+var pull = require('pull-stream')
+
+var testStreamValues = [{
+  "val": "first",
+  sequenceNumber: 1
+}, {
+  "val": "second",
+  sequenceNumber: 2
+}, {
+  "val": "third",
+  sequenceNumber: 3
+}, {
+  "val": "fourth",
+  sequenceNumber: 4
+}];
+
+var testStream = pull.values(testStreamValues);
+
+test('A stream is completed in the same order', function(t) {
+  var testStream = pull.values(testStreamValues);
+
+  var mpr = MutantPullReduce(() => testStream, (state, item) => {
+    state.push(item);
+    return state;
+  }, {
+    startValue: []
+  })
+
+  var startValue = mpr();
+
+  t.deepEquals(startValue, []);
+
+  mpr(v => {})
+
+  var endValue = mpr();
+  t.deepEquals(endValue, testStreamValues)
+
+  t.end();
+
+})
+
+
+test('A pull-stream can be resumed.', function(t) {
+  var timesStart = 0;
+  var timesResume = 0;
+
+  var getStream = (latest) => {
+
+    if (!latest) {
+      timesStart = timesStart + 1
+      return testStream
+    } else {
+      timesResume = timesResume + 1
+      var latestSequence = latest.sequenceNumber;
+      return pull(testStream, pull.filter(item => item.sequenceNumber > latestSequence))
+    }
+  }
+
+  var reducer = (latestValue, item) => item;
+
+  var observable = MutantPullReduce(getStream, reducer, {
+    startValue: 0
+  });
+
+  let unsubscribe = observable((value) => {
+    if (value.sequenceNumber === 2) {
+      unsubscribe()
+    }
+  });
+
+  t.deepEquals(observable() , testStreamValues[1])
+  t.deepEquals(timesStart, 1);
+  t.deepEquals(timesResume, 0);
+
+  var subscribeRest = observable(
+    (value) => {
+      // noop
+    }
+  );
+
+  t.deepEquals(observable() , testStreamValues[3])
+
+  t.deepEquals(timesStart, 1);
+  t.deepEquals(timesResume, 1);
+
+  t.end();
+
+})

--- a/test/test-resume-stream.js
+++ b/test/test-resume-stream.js
@@ -35,12 +35,12 @@ test('A stream is completed in the same order', function(t) {
 
   var startValue = mpr();
 
-  t.deepEquals(startValue, []);
+  t.deepEquals(startValue, [], "Expect the start value to be respected.");
 
   mpr(v => {})
 
   var endValue = mpr();
-  t.deepEquals(endValue, testStreamValues)
+  t.deepEquals(endValue, testStreamValues, "When just collecting the values from the stream, expect the ordering to be the same.")
 
   t.end();
 
@@ -66,18 +66,20 @@ test('A pull-stream can be resumed.', function(t) {
   var reducer = (latestValue, item) => item;
 
   var observable = MutantPullReduce(getStream, reducer, {
-    startValue: 0
+    startValue: 0,
+    nextTick: true
   });
 
-  let unsubscribe = observable((value) => {
+  var unsubscribe = observable((value) => {
     if (value.sequenceNumber === 2) {
-      unsubscribe()
+      t.comment("unsubbing.")
+      test.unsubscribe()
     }
   });
 
-  t.deepEquals(observable() , testStreamValues[1])
-  t.deepEquals(timesStart, 1);
-  t.deepEquals(timesResume, 0);
+  t.deepEquals(observable() , testStreamValues[1], "Expect the stream to stop after all ununsubscriptions.")
+  t.deepEquals(timesStart, 1, "Expect the 'start stream' to only be invoked once.");
+  t.deepEquals(timesResume, 0, "Expect the 'resume stream' path to not be invoked yet.");
 
   var subscribeRest = observable(
     (value) => {
@@ -85,10 +87,10 @@ test('A pull-stream can be resumed.', function(t) {
     }
   );
 
-  t.deepEquals(observable() , testStreamValues[3])
+  t.deepEquals(observable() , testStreamValues[3], "Expect the end of the stream to be reached after re-subscribing")
 
-  t.deepEquals(timesStart, 1);
-  t.deepEquals(timesResume, 1);
+  t.deepEquals(timesStart, 1, "Expect 'start stream' to have only been invoked once after re-subscribing");
+  t.deepEquals(timesResume, 1, "Expect 'resume stream' to have been invoked after re-subscribing");
 
   t.end();
 

--- a/test/test-resume-stream.js
+++ b/test/test-resume-stream.js
@@ -13,6 +13,11 @@ var testStreamValues = [{
 }, {
   "val": "second",
   sequenceNumber: 2
+},
+// This shouldn't be reached after the abort
+{
+  "val": "third",
+  sequenceNumber: 3
 }];
 
 var testStream = pull.values(testStreamValues);
@@ -84,7 +89,6 @@ test('A pull-stream can be resumed.', function(t) {
   var reducer = (latestValue, item) => item;
 
   var observable = MutantPullReduce(getStream, reducer, {
-    startValue: 0,
     nextTick: true
   });
 
@@ -98,13 +102,14 @@ test('A pull-stream can be resumed.', function(t) {
   var subscribeRest = observable(
     (value) => {
       // noop
+      console.log(value)
     }
   );
 
-  t.deepEquals(observable() , testStreamValues2[1], "Expect the end of the stream to be reached after re-subscribing")
-
   t.deepEquals(timesStart, 1, "Expect 'start stream' to have only been invoked once after re-subscribing");
   t.deepEquals(timesResume, 1, "Expect 'resume stream' to have been invoked after re-subscribing");
+
+  t.deepEquals(observable() , testStreamValues2[1], "Expect the end of the stream to be reached after re-subscribing")
 
   t.end();
 


### PR DESCRIPTION
Sorry about all the pull requests I've been throwing your way recently @mmckegg =p. Look at them whenever - no expectations / rush / pressure!

When I was doing some work to remove listeners to observables in `ssb-chess` recently, I noticed that the streams for the mutant-pull-reduce  lists underlying my chess games weren't getting closed (I'd added a print statement to the start of the stream, and was wondering why it was still printing when the observable had been unlistened.) I ended up with a bunch of unclosed streams for the same source (the live feed with timestamp gt than something.)

I'm not sure if the messages were still getting printed, regardless of the 'pauser', because it was from a live stream and they were getting pushed anyway.

I'd like to remove the streams for games entirely when the page for the boards are navigated away from, and open a new observable when the game (or list of mini-boards for games) is returned to.

Does adding an option to abort when there are no listeners left, rather than pause, make sense to you?